### PR TITLE
Add language filter and selector

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -4,7 +4,7 @@ import * as Component from "./quartz/components"
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
-  header: [],
+  header: [Component.LanguageSelector()],
   afterBody: [],
   footer: Component.Footer({
     links: {

--- a/quartz/components/LanguageSelector.tsx
+++ b/quartz/components/LanguageSelector.tsx
@@ -1,0 +1,19 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+// @ts-ignore
+import script from "./scripts/language.inline"
+import style from "./styles/languageSelector.scss"
+
+const LanguageSelector: QuartzComponent = ({ }: QuartzComponentProps) => {
+  return (
+    <select id="language-select" class="language-select">
+      <option value="ko">한국어</option>
+      <option value="ja">日本語</option>
+      <option value="en">English</option>
+    </select>
+  )
+}
+
+LanguageSelector.afterDOMLoaded = script
+LanguageSelector.css = style
+
+export default (() => LanguageSelector) satisfies QuartzComponentConstructor

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -42,9 +42,16 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort
       {list.map((page) => {
         const title = page.frontmatter?.title
         const tags = page.frontmatter?.tags ?? []
+        const langsRaw = page.frontmatter?.languages as string[] | string | undefined
+        const langsArr = langsRaw
+          ? Array.isArray(langsRaw)
+            ? langsRaw
+            : [langsRaw]
+          : ["ko"]
+        const dataLang = langsArr.join(",")
 
         return (
-          <li class="section-li">
+          <li class="section-li" data-lang={dataLang}>
             <div class="section">
               <p class="meta">
                 {page.dates && <Date date={getDate(cfg, page)!} locale={cfg.locale} />}

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -42,9 +42,12 @@ export default ((userOpts?: Partial<Options>) => {
           {pages.slice(0, opts.limit).map((page) => {
             const title = page.frontmatter?.title ?? i18n(cfg.locale).propertyDefaults.title
             const tags = page.frontmatter?.tags ?? []
+            const langsRaw = page.frontmatter?.languages as string[] | string | undefined
+            const langsArr = langsRaw ? (Array.isArray(langsRaw) ? langsRaw : [langsRaw]) : ["ko"]
+            const dataLang = langsArr.join(",")
 
             return (
-              <li class="recent-li">
+              <li class="recent-li" data-lang={dataLang}>
                 <div class="section">
                   <div class="desc">
                     <h3>

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -20,6 +20,7 @@ import MobileOnly from "./MobileOnly"
 import RecentNotes from "./RecentNotes"
 import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
+import LanguageSelector from "./LanguageSelector"
 
 export {
   ArticleTitle,
@@ -44,4 +45,5 @@ export {
   NotFound,
   Breadcrumbs,
   Comments,
+  LanguageSelector,
 }

--- a/quartz/components/scripts/language.inline.ts
+++ b/quartz/components/scripts/language.inline.ts
@@ -1,0 +1,28 @@
+const DEFAULT_LANG = "ko";
+
+function applyLanguage(lang: string) {
+  document.querySelectorAll<HTMLElement>("[data-lang]").forEach((el) => {
+    const langs = (el.getAttribute("data-lang") || DEFAULT_LANG).split(",");
+    if (langs.includes(lang)) {
+      el.classList.remove("lang-hidden");
+    } else {
+      el.classList.add("lang-hidden");
+    }
+  });
+}
+
+document.addEventListener("nav", () => {
+  const selector = document.getElementById("language-select") as HTMLSelectElement | null;
+  if (!selector) return;
+  const stored = localStorage.getItem("language") || DEFAULT_LANG;
+  selector.value = stored;
+  applyLanguage(stored);
+
+  const onChange = () => {
+    const lang = selector.value;
+    localStorage.setItem("language", lang);
+    applyLanguage(lang);
+  };
+  selector.addEventListener("change", onChange);
+  window.addCleanup(() => selector.removeEventListener("change", onChange));
+});

--- a/quartz/components/styles/languageSelector.scss
+++ b/quartz/components/styles/languageSelector.scss
@@ -1,0 +1,13 @@
+.language-select {
+  background-color: var(--lightgray);
+  border: none;
+  border-radius: 4px;
+  height: 2rem;
+  padding: 0 0.5rem;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.lang-hidden {
+  display: none !important;
+}

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -71,6 +71,9 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             const cssclasses = coerceToArray(coalesceAliases(data, ["cssclasses", "cssclass"]))
             if (cssclasses) data.cssclasses = cssclasses
 
+            const languages = coerceToArray(coalesceAliases(data, ["languages", "language"])) ?? ["ko"]
+            data.languages = languages
+
             const socialImage = coalesceAliases(data, ["socialImage", "image", "cover"])
 
             if (socialImage) data.socialImage = socialImage
@@ -99,6 +102,7 @@ declare module "vfile" {
         cssclasses: string[]
         socialImage: string
         comments: boolean | string
+        languages: string[]
       }>
   }
 }


### PR DESCRIPTION
## Summary
- support `languages` frontmatter with default Korean fallback
- add `LanguageSelector` component with runtime filtering script
- integrate selector into layout header
- tag page list and recent notes with `data-lang` for filtering

## Testing
- `npm run check` *(fails: Cannot find module 'source-map-support' and other type errors)*